### PR TITLE
Update and rename rubocop.yml

### DIFF
--- a/config_files/.rubocop.yml
+++ b/config_files/.rubocop.yml
@@ -1,3 +1,5 @@
+require: 'rubocop-rails'
+
 AllCops:
   Exclude:
     - 'vendor/**/*'


### PR DESCRIPTION
Default rubocop.yml name begins with dot: .rubocop.yml
Since it contains rules for rubocop-rails we should require it.